### PR TITLE
Use unitTax to calculate tax if available

### DIFF
--- a/src/Basket/BasketItem.php
+++ b/src/Basket/BasketItem.php
@@ -94,6 +94,11 @@ class BasketItem implements BasketItemInterface
 		if (isset($this->tax)) {
 			return $this->tax;
 		}
+
+		if (isset($this->data['unitTax'])) {
+			return $this->unitTax * $this->quantity;
+		}
+
 		return round($this->subtotal() * $this->taxRate() / 100, 2);
 	}
 


### PR DESCRIPTION
If the tax for each unit of a basket item has
been specified then use that value to calculate
the tax on a basket item instead of calculating it
from the subtotal and tax rate.